### PR TITLE
Update README.md to reference account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
     - [Provisioning status](jetpack/determining-provisioning-status.md)
   - [Managing modules](jetpack/managing-modules.md)
   - [Upgrade redirection](jetpack/upgrade-redirection.md)
-  - [Automatic account creation](jetpack/automatic-account-creation-connection.md)
 - WooCommerce
   - [Overview](woocommerce/overview.md)
   - [Provison/Register plan](woocommerce/plan-register.md)
   - [Cancel plan](woocommerce/plan-cancel.md)
   - [Update URL for a site](woocommerce/update-url.md)
   - [Extension information](woocommerce/extension-info.md)
+- Account creation
+  - [Creating users via /jpphp/user endpoint](users/user-creation.md)
+  - [Automatic account creation via Jetpack](jetpack/automatic-account-creation-connection.md)
 
 ## Become a hosting partner
 


### PR DESCRIPTION
There are two separate methods for creating users to provision plans to:

1) Via the /jpphp/user endpoint with a `jetpack-partner` token
2) Via provisioning a Jetpack plan

This PR rearranges slightly so that we're referencing both methods.