### PR TITLE
Update references from extension info to product info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Provison/Register plan](woocommerce/plan-register.md)
   - [Cancel plan](woocommerce/plan-cancel.md)
   - [Update URL for a site](woocommerce/update-url.md)
-  - [Extension information](woocommerce/extension-info.md)
+  - [Product information](woocommerce/product-info.md)
   - [Considerations for WP-CLI](woocommerce/considerations-for-wp-cli.md)
 - Account creation
   - [Creating users via /jpphp/user endpoint](users/user-creation.md)

--- a/woocommerce/overview.md
+++ b/woocommerce/overview.md
@@ -56,8 +56,8 @@ Below, we'll go over the various integration steps that a hosting partner will n
 
    Documentation can be found [here](update-url.md).
 
-1. **Package/Extension Information**
+1. **Package/Product Information**
 
-   Get information about products in a package / host plan. Response includes latest version and download URL to our internal repository, and as such, that makes these endpoints important for ensuring that a hosting partner is installing the latest WooCommerce extensions from their package.
+   Get information about products in a package / host plan. Response includes latest version and download URL to our internal repository, and as such, that makes these endpoints important for ensuring that a hosting partner is installing the latest WooCommerce products from their package.
 
-   Documentation can be found [here](extension-info.md).
+   Documentation can be found [here](product-info.md).

--- a/woocommerce/product-info.md
+++ b/woocommerce/product-info.md
@@ -1,10 +1,11 @@
-# Extension Information
+# Package Information
 
-The following endpoints will allow you to retrieve information about all extensions for a package or a single extension from a package. The expected information for an extension will look like this:
+The following endpoints will allow you to retrieve information about all products for a package or a single product from a package. The expected information for a product will look like this:
 
 ```json
 {
   "name": "Facebook for WooCommerce",
+  "type": "plugin",
   "version": "1.9.6",
   "last_updated": "2018-09-21",
   "download_link": "http://woothemes-products.s3.amazonaws.com/plugin-packages/facebook-for-woocommerce/facebook-for-woocommerce.zip?AWSAccessKeyId=AKIAJE6A7GBT4ZRLENMA&Expires=1541139531&Signature=iJMJrkCsUqJNPvctF3HQVZ2ubMI%3D",
@@ -14,9 +15,11 @@ The following endpoints will allow you to retrieve information about all extensi
 }
 ```
 
-## All Extensions Information
+**Note:** `type` is not supplied in the `/info/<slug>.json` endpoint.
 
-Get information all of the extensions in a package.
+## All Products Information
+
+Get information all of the products in a package.
 
 ```code
 GET /info
@@ -137,7 +140,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-## Single Extension Information
+## Single Product Information
 
 Get information about a product in a package.
 


### PR DESCRIPTION
The documentation for the `/info` and `/info/<slug>.json` endpoints previously mentioned extensions, even though the endpoint also returns information for themes. This PR fixes that.