### PR TITLE
Adds v2.0 documentation for WooCommerce register

### DIFF
--- a/woocommerce/plan-register.md
+++ b/woocommerce/plan-register.md
@@ -2,13 +2,68 @@
 
 Register a new WooCommerce.com customer with initial order of a host plan.
 
-```
+```code
 POST /register
 ```
 
+- [API v2.0](#api-v20)
+  - Simplifies arguments required for registering a plan. Returns same response as v1.0.
+- [API v1.0](#api-v10)
+
+## API v2.0
+
 Example request and response:
 
+```code
+curl -i -X POST 'https://woocommerce.com/wp-json/wccom/host-plan/v2.0/register' \
+  -H 'Authorization: Bearer <key>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com",
+    "wpcom_access_token": "#K(EkA1*$gx*!JrC#DCe45meEAllcnXjhKNM2Eu!if%^BAAx3z(AaOw@t(CVFnjK)))"
+}'
+
+HTTP/1.1 200 OK
+{
+  "customer_id":1872797,
+  "order_id":2666930,
+  "access_token":"e95a8cc87027ec3c303e904d2ea69dd8e0ad0acf",
+  "access_token_secret":"f71287fdce053102c71536b1648f27657e8be912",
+  "site_id":42506
+}
 ```
+
+### Parameters v2.0
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `url` | `string` | Customer site URL. |
+| `wpcom_accesss_token` | `string` | WordPress.com user access token. |
+| `products` | `array` | Array of product slugs. This is optional. |
+
+```code
+{
+  "url": "https://example.com",
+  "customer": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "email": "john.doe@example.com",
+    "wpcom_user_id": 123,
+    "wpcom_access_token": "#K(EkA1*$gx*!JrC#DCe45meEAllcnXjhKNM2Eu!if%^BAAx3z(AaOw@t(CVFnjK)))"
+  },
+  "products": [ 'facebook-for-woocommerce', 'woocommerce-shipping-ups' ]
+}
+```
+
+### Response v2.0
+
+Unchanged from [v1.0](#response-v10).
+
+## API v1.0
+
+Example request and response:
+
+```code
 curl -i -X POST 'https://woocommerce.com/wp-json/wccom/host-plan/v1.0/register' \
   -H 'Authorization: Bearer <key>' \
   -H 'Content-Type: application/json' \
@@ -31,14 +86,13 @@ HTTP/1.1 200 OK
 }
 ```
 
-## Parameters
+### Parameters v1.0
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `url` | `string` | Customer site URL. |
 | `customer` | `object` | Customer object. See below. |
 | `products` | `array` | Array of product slugs. This is optional. |
-
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -48,7 +102,7 @@ HTTP/1.1 200 OK
 | `wpcom_user_id` | `integer` | WordPress.com user ID. Optional if `wpcom_accesss_token` is passed and will be deprecated in the future. |
 | `wpcom_accesss_token` | `string` | WordPress.com user access token. |
 
-```
+```code
 {
   "url": "https://example.com",
   "customer": {
@@ -62,7 +116,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-## Response
+### Response v1.0
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -72,7 +126,7 @@ HTTP/1.1 200 OK
 | `access_token_secret` | `string` | Customer access token secret. |
 | `site_id` | `number` | Customer site ID in WooCommerce.com. |
 
-```
+```code
 HTTP/1.1 200 OK
 {
   "customer_id":1872797,


### PR DESCRIPTION
This PR adds documentation for the v2.0 WooCommerce host-plan endpoints, specifically for `/register`. Before we merge this, let's be sure that the endpoints are in production.