### PR TITLE
Add reporting endpoints documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Update URL for a site](woocommerce/update-url.md)
   - [Product information](woocommerce/product-info.md)
   - [Management via WP-CLI](woocommerce/management-via-wp-cli.md)
+  - [Reporting Endpoints](woocommerce/reporting-endpoints.md)
 - Account creation
   - [Creating users via /jpphp/user endpoint](users/user-creation.md)
   - [Automatic account creation via Jetpack](jetpack/automatic-account-creation-connection.md)

--- a/woocommerce/reporting-endpoints.md
+++ b/woocommerce/reporting-endpoints.md
@@ -1,0 +1,182 @@
+# WooCommerce Reporting Endpoints
+
+The following are endpoints used to retrieve stats for a given host plan, identified by the partner's bearer token.
+
+## List orders
+
+List all host-plan orders created to the authenticated host-plan.
+
+```code
+GET /orders
+```
+
+### Parameters (/orders)
+
+|  Name | Description |
+| ------ | ------------ |
+| `before` | Limit response to host-plan orders created before a given ISO8601 compliant date. |
+| `after` | Limit response to host-plan orders created after a given ISO8601 compliant date. |
+| `status` | Limit result set to host-plan orders assigned one or more statuses. Default: `completed`. |
+| `customer_id` | Limit result set to host-plan orders assigned a specific customer ID. |
+| `page` |  Current page of the collection. Default is `1`. |
+| `per_page` | Maximum number of items to be returned in result set. Default is `20`. Maximum `100`. |
+| `offset` | Offset the result set by a specific number of items. |
+
+### Response (/orders)
+
+```
+Status: 200 OK
+X-WP-Total: 500
+X-WP-TotalPages: 5
+Link: <https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=2>; rel="next",
+<https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=5>; rel="last"
+
+[
+  {
+    "id": 2666760,
+    "status": "completed",
+    "date_created": "2019-03-20T20:39:38",
+    "date_created_gmt": "2019-03-20T18:39:38",
+    "date_modified": "2019-03-20T20:39:38",
+    "date_modified_gmt": "2019-03-20T18:39:38",
+    "customer_id": 1872783,
+    "customer_email": "akeda.bagus+wccom-host-plan-001@automattic.com",
+    "line_items": [
+      {
+        "name": "GoDaddy eCommerce Plan",
+      }
+    ],
+  },
+  ...
+]
+```
+
+## Get a single order
+
+Get a single host-plan order.
+
+```code
+GET /orders/<order_id>
+```
+
+### Response (orders/<order_id>)
+
+```code
+Status: 200 OK
+
+{
+  "id": 2666760,
+  "status": "completed",
+  "date_created": "2019-03-20T20:39:38",
+  "date_created_gmt": "2019-03-20T18:39:38",
+  "date_modified": "2019-03-20T20:39:38",
+  "date_modified_gmt": "2019-03-20T18:39:38",
+  "customer_id": 1872783,
+  "customer_email": "akeda.bagus+wccom-host-plan-001@automattic.com",
+  "line_items": [
+    {
+      "name": "GoDaddy eCommerce Plan",
+    }
+  ],
+}
+```
+
+## List order connections
+
+List all connected products in an order.
+
+```code
+GET /orders/<order_id>/connections
+```
+
+### Response (/orders/<order_id>/connections)
+
+```code
+Status: 200 OK
+
+[
+  {
+    "product_slug": "woocommerce-shipping-usps",
+    "url": "https://example.com"
+  },
+  ...
+],
+```
+
+## Get a single site
+
+Get a single host-plan site.
+
+```code
+GET /sites/<site_id>
+```
+
+### Response /sites/<site_id>
+
+```code
+Status: 200 OK
+
+{
+  "order_ids": {
+    "completed": [
+        123,
+        456,
+      ],
+    "cancelled": [
+        234,
+        567,
+      ]
+  },
+  "connections": [
+    {
+      "product_slug": "wocommerce-shipping-ups",
+      "order_id": 123
+    },
+    ...
+  ]
+}
+```
+
+## Get totals
+
+Get totals of orders and connected products over time.
+
+```code
+GET /totals
+```
+
+### Response (/totals)
+
+```code
+Status: 200 OK
+
+{
+  "total_orders": {
+    "completed": 900,
+    "cancelled": 100
+  },
+  "total_orders_by_month" : {
+    "1-2019": {
+      "completed": 450,
+      "cancelled": 50
+    },
+    "2-2019": {
+      "completed": 450,
+      "cancelled": 50
+    },
+  },
+  "total_connections": {
+    "woocommerce-shipping-usps": 500,
+    "woocommerce-product-addons": 500,
+    ...
+  },
+  "total_connections_by_month": {
+    "1-2019": {
+      "woocommerce-shipping-usps": 500,
+      "woocommerce-product-addons": 500,
+      ...
+    },
+    ...
+  }
+}
+```


### PR DESCRIPTION
This PR takes a first pass at adding documentation for reporting endpoints for WooCommerce plans.

Before merging, we should include some example requests at a minimum.