### PR TITLE
Add examples of request and response to WooCommerce reporting endpoints

### DIFF
--- a/woocommerce/reporting-endpoints.md
+++ b/woocommerce/reporting-endpoints.md
@@ -111,6 +111,32 @@ Status: 200 OK
 }
 ```
 
+### Example Request and Response (orders/<order_id>)
+
+```code
+curl -i -X GET \
+  https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders/3960664 \
+  -H 'Authorization: Bearer <key>' \
+  -H 'cache-control: no-cache'
+
+HTTP/2 200
+{
+    "id": 3960664,
+    "status": "completed",
+    "date_created": "2019-03-21T21:05:13",
+    "date_created_gmt": "2019-03-21T19:05:13",
+    "date_modified": "2019-03-21T21:05:13",
+    "date_modified_gmt": "2019-03-21T19:05:13",
+    "customer_id": 1208567,
+    "customer_email": "user@example.com",
+    "line_items": [
+        {
+            "name": "eCommerce Plan"
+        }
+    ]
+}
+```
+
 ## List order connections
 
 List all connected products in an order.

--- a/woocommerce/reporting-endpoints.md
+++ b/woocommerce/reporting-endpoints.md
@@ -24,7 +24,7 @@ GET /orders
 
 ### Response (/orders)
 
-```
+```code
 Status: 200 OK
 X-WP-Total: 500
 X-WP-TotalPages: 5
@@ -49,6 +49,36 @@ Link: <https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=2>; rel=
   },
   ...
 ]
+```
+
+### Example Request and Response (orders)
+
+```code
+curl -i -X GET \
+  https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders \
+  -H 'Authorization: Bearer <key>' \
+  -H 'cache-control: no-cache'
+
+HTTP/2 200
+[
+    {
+        "id": 3960664,
+        "status": "completed",
+        "date_created": "2019-03-21T21:05:13",
+        "date_created_gmt": "2019-03-21T19:05:13",
+        "date_modified": "2019-03-21T21:05:13",
+        "date_modified_gmt": "2019-03-21T19:05:13",
+        "customer_id": 1208567,
+        "customer_email": "user@example.com",
+        "line_items": [
+            {
+                "name": "eCommerce Plan"
+            }
+        ]
+    },
+    ...
+]
+
 ```
 
 ## Get a single order


### PR DESCRIPTION
The current reporting endpoints could use some love in the way of some example requests and responses to illustrate how the endpoints work. This PR will provide those examples.

This PR is in progress.