### PR TITLE
WooCommerce: Add example to reporting endpoints

### DIFF
--- a/woocommerce/reporting-endpoints.md
+++ b/woocommerce/reporting-endpoints.md
@@ -22,32 +22,87 @@ GET /orders
 | `per_page` | Maximum number of items to be returned in result set. Default is `20`. Maximum `100`. |
 | `offset` | Offset the result set by a specific number of items. |
 
-### Response (/orders)
+### Example request and response (/orders)
 
-```
-Status: 200 OK
-X-WP-Total: 500
-X-WP-TotalPages: 5
-Link: <https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=2>; rel="next",
-<https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=5>; rel="last"
-
+```code
+curl -i -X  GET \
+  --url https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders \
+  --header 'Authorization: Bearer <key>' \
+  --header 'cache-control: no-cache'
+HTTP/2 200
+server: nginx
+date: Fri, 14 Jun 2019 14:38:17 GMT
+content-type: application/json; charset=UTF-8
+content-length: 6667
+x-robots-tag: noindex
+x-content-type-options: nosniff
+access-control-expose-headers: X-WP-Total, X-WP-TotalPages
+access-control-allow-headers: Authorization, Content-Type
+x-wp-total: 615
+x-wp-totalpages: 31
+link: <https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders?page=2>; rel="next"
+cache-control: max-age=60
+allow: GET
+x-rq: dfw1 82 50 3130
+age: 0
+x-cache: pass
+accept-ranges: bytes
 [
-  {
-    "id": 2666760,
-    "status": "completed",
-    "date_created": "2019-03-20T20:39:38",
-    "date_created_gmt": "2019-03-20T18:39:38",
-    "date_modified": "2019-03-20T20:39:38",
-    "date_modified_gmt": "2019-03-20T18:39:38",
-    "customer_id": 1872783,
-    "customer_email": "akeda.bagus+wccom-host-plan-001@automattic.com",
-    "line_items": [
-      {
-        "name": "eCommerce Plan",
-      }
-    ],
-  },
-  ...
+    {
+        "id": 4263050,
+        "status": "completed",
+        "date_created": "2019-06-12T21:53:45",
+        "date_created_gmt": "2019-06-12T19:53:45",
+        "date_modified": "2019-06-12T21:53:45",
+        "date_modified_gmt": "2019-06-12T19:53:45",
+        "customer_id": 123,
+        "customer_email": "user@example.com",
+        "line_items": [
+            {
+                "name": "eCommerce Plan"
+            },
+            {
+                "name": "WooCommerce Bookings"
+            }
+        ]
+    },
+    {
+        "id": 4262968,
+        "status": "completed",
+        "date_created": "2019-06-12T21:26:56",
+        "date_created_gmt": "2019-06-12T19:26:56",
+        "date_modified": "2019-06-12T21:26:56",
+        "date_modified_gmt": "2019-06-12T19:26:56",
+        "customer_id": 124,
+        "customer_email": "user@example.com",
+        "line_items": [
+            {
+                "name": "eCommerce Plan"
+            },
+            {
+                "name": "WooCommerce Bookings"
+            }
+        ]
+    },
+    {
+        "id": 4262918,
+        "status": "completed",
+        "date_created": "2019-06-12T21:13:26",
+        "date_created_gmt": "2019-06-12T19:13:26",
+        "date_modified": "2019-06-12T21:13:26",
+        "date_modified_gmt": "2019-06-12T19:13:26",
+        "customer_id": 125,
+        "customer_email": "user@example.com",
+        "line_items": [
+            {
+                "name": "eCommerce Plan"
+            },
+            {
+                "name": "WooCommerce Bookings"
+            }
+        ]
+    },
+    ...
 ]
 ```
 
@@ -59,25 +114,47 @@ Get a single host-plan order.
 GET /orders/<order_id>
 ```
 
-### Response (orders/<order_id>)
+### Example request and response (orders/order_id)
 
 ```code
-Status: 200 OK
+curl -i -X  GET \
+  --url https://woocommerce.com/wp-json/wccom/host-plan/v2.0/orders/4262918 \
+  --header 'Authorization: Bearer <key>' \
+  --header 'cache-control: no-cache'
+HTTP/2 200
+server: nginx
+date: Fri, 14 Jun 2019 14:36:31 GMT
+content-type: application/json; charset=UTF-8
+content-length: 344
+x-robots-tag: noindex
+link: <https://woocommerce.com/wp-json/>; rel="https://api.w.org/"
+x-content-type-options: nosniff
+access-control-expose-headers: X-WP-Total, X-WP-TotalPages
+access-control-allow-headers: Authorization, Content-Type
+cache-control: max-age=60
+allow: GET
+x-rq: dfw2 87 152 3154
+age: 0
+x-cache: pass
+accept-ranges: bytes
 
 {
-  "id": 2666760,
-  "status": "completed",
-  "date_created": "2019-03-20T20:39:38",
-  "date_created_gmt": "2019-03-20T18:39:38",
-  "date_modified": "2019-03-20T20:39:38",
-  "date_modified_gmt": "2019-03-20T18:39:38",
-  "customer_id": 1872783,
-  "customer_email": "akeda.bagus+wccom-host-plan-001@automattic.com",
-  "line_items": [
-    {
-      "name": "eCommerce Plan",
-    }
-  ],
+    "id": 4262918,
+    "status": "completed",
+    "date_created": "2019-06-12T21:13:26",
+    "date_created_gmt": "2019-06-12T19:13:26",
+    "date_modified": "2019-06-12T21:13:26",
+    "date_modified_gmt": "2019-06-12T19:13:26",
+    "customer_id": 2442392,
+    "customer_email": "user@example.com",
+    "line_items": [
+        {
+            "name": "eCommerce Plan"
+        },
+        {
+            "name": "WooCommerce Bookings"
+        }
+    ]
 }
 ```
 
@@ -89,7 +166,7 @@ List all connected products in an order.
 GET /orders/<order_id>/connections
 ```
 
-### Response (/orders/<order_id>/connections)
+### Response (/orders/order_id/connections)
 
 ```code
 Status: 200 OK
@@ -111,29 +188,47 @@ Get a single host-plan site.
 GET /sites/<site_id>
 ```
 
-### Response /sites/<site_id>
+### Example request and response (/sites/site_id)
 
 ```code
-Status: 200 OK
+curl -i -X GET \
+  --url https://woocommerce.com/wp-json/wccom/host-plan/v2.0/sites/196037 \
+  --header 'Authorization: Bearer <key>' \
+  --header 'Cache-Control: no-cache'
+HTTP/2 200
+server: nginx
+date: Fri, 14 Jun 2019 18:18:27 GMT
+content-type: application/json; charset=UTF-8
+content-length: 263
+x-robots-tag: noindex
+link: <https://woocommerce.com/wp-json/>; rel="https://api.w.org/"
+x-content-type-options: nosniff
+access-control-expose-headers: X-WP-Total, X-WP-TotalPages
+access-control-allow-headers: Authorization, Content-Type
+cache-control: max-age=60
+allow: GET
+x-rq: dfw2 91 202 3159
+age: 0
+x-cache: pass
+accept-ranges: bytes
 
 {
-  "order_ids": {
-    "completed": [
-        123,
-        456,
-      ],
-    "cancelled": [
-        234,
-        567,
-      ]
-  },
-  "connections": [
-    {
-      "product_slug": "wocommerce-shipping-ups",
-      "order_id": 123
+    "order_ids": {
+        "completed": [],
+        "cancelled": []
     },
-    ...
-  ]
+    "connections": [
+        {
+            "order_id": "3960664",
+            "site_url": "example.com",
+            "product_slug": "USPS Shipping Method"
+        },
+        {
+            "order_id": "3960664",
+            "site_url": "example.com",
+            "product_slug": "WooCommerce Bookings"
+        }
+    ]
 }
 ```
 
@@ -145,38 +240,70 @@ Get totals of orders and connected products over time.
 GET /totals
 ```
 
-### Response (/totals)
+### Example request and response (/totals)
 
 ```code
-Status: 200 OK
+curl -i -X GET \
+  --url https://woocommerce.com/wp-json/wccom/host-plan/v2.0/totals \
+  --header 'Authorization: Bearer <key>' \
+  --header 'Cache-Control: no-cache'
+HTTP/2 200
+server: nginx
+date: Fri, 14 Jun 2019 18:25:10 GMT
+content-type: application/json; charset=UTF-8
+x-robots-tag: noindex
+link: <https://woocommerce.com/wp-json/>; rel="https://api.w.org/"
+x-content-type-options: nosniff
+access-control-expose-headers: X-WP-Total, X-WP-TotalPages
+access-control-allow-headers: Authorization, Content-Type
+cache-control: max-age=60
+allow: GET
+x-rq: dfw2 87 42 3168
+age: 0
+x-cache: pass
+accept-ranges: bytes
 
 {
-  "total_orders": {
-    "completed": 900,
-    "cancelled": 100
-  },
-  "total_orders_by_month" : {
-    "1-2019": {
-      "completed": 450,
-      "cancelled": 50
+    "total_orders": {
+        "completed": 615,
+        "cancelled": 56
     },
-    "2-2019": {
-      "completed": 450,
-      "cancelled": 50
+    "total_connections": {
+        "woocommerce-xero": 1,
+        "wooslider": 7,
+        "woocommerce-bookings": 13,
+        "woocommerce-shipping-usps": 2,
+        "woothemes-sensei": 2,
+        "woocommerce-eu-vat-number": 1,
+        "woocommerce-gateway-paypal-pro": 2,
+        "woocommerce-shipping-ups": 1,
+        "woocommerce-product-csv-import-suite": 2,
+        "woocommerce-software-add-on": 2,
+        "woocommerce-table-rate-shipping": 1,
+        "woocommerce-product-vendors": 3
     },
-  },
-  "total_connections": {
-    "woocommerce-shipping-usps": 500,
-    "woocommerce-product-addons": 500,
-    ...
-  },
-  "total_connections_by_month": {
-    "1-2019": {
-      "woocommerce-shipping-usps": 500,
-      "woocommerce-product-addons": 500,
-      ...
+    "total_orders_by_month": {
+        ...
+        "6-2019": {
+            "completed": 105,
+            "cancelled": 28
+        }
     },
-    ...
-  }
+    "total_connections_by_month": {
+        ...
+        "6-2019": {
+            "woocommerce-eu-vat-number": 1,
+            "woocommerce-gateway-paypal-pro": 2,
+            "woocommerce-shipping-usps": 1,
+            "woocommerce-shipping-ups": 1,
+            "woocommerce-product-csv-import-suite": 2,
+            "woocommerce-software-add-on": 2,
+            "woocommerce-table-rate-shipping": 1,
+            "wooslider": 5,
+            "woothemes-sensei": 1,
+            "woocommerce-product-vendors": 3,
+            "woocommerce-bookings": 8
+        }
+    }
 }
 ```


### PR DESCRIPTION
Adds some better examples of how to call the reporting endpoints as well as what data to expect back. 

Note: The /orders/<order_id>/connections endpoint does not have a better example since it seems to be having some issues. I've reported the issues to the WooCommerce.com repo.