### PR TITLE
Added SSH credentials documentation for partner-provision.sh

### DIFF
--- a/jetpack/plan-provisioning-direct-api.md
+++ b/jetpack/plan-provisioning-direct-api.md
@@ -113,7 +113,7 @@ Plans can be provisioned by making a request using your partner token from the s
 - __ssh_host__:        (optional) Set SSH host. Will be deduced from `siteurl` if missing.
 - __ssh_port__:        (optional) Set SSH port. Will default to 22 is missing.
 
-_Note: All the SSH parameters are optional but if you pass `ssh_user` you will need to either pass `ssh_pass` or `ssh_private_key`._
+_Note: All the SSH parameters are optional but if you pass `ssh_user` you will need to either pass `ssh_pass` or `ssh_private_key`. Setting SSH credentials is currently in beta._
 
 ### Response Parameters (/provision)
 

--- a/jetpack/plan-provisioning.md
+++ b/jetpack/plan-provisioning.md
@@ -31,6 +31,13 @@ Further in this document, you will find a few CLI commands with various argument
 - `onboarding`            : This optional value can be set to `1` to enabled an onboarding wizard.
 - `partner_tracking_id`   : This optional value allows us to attach specific actions to a specific site on the partner's side. This has proved useful in cases where users had multiple staging sites.
 - `wp-cli-path`           : Allows setting the path of WP-CLI.
+- `ssh-host`              : The SSH host for Jetpack Backups remote access.
+- `ssh-user`              : The SSH user for Jetpack Backups remote access.
+- `ssh-pass`              : The SSH password for Jetpack Backups remote access.
+- `ssh-private-key`       : The local path to the SSH private key file for Jetpack Backups remote access.
+- `ssh-port`              : The SSH port for Jetpack Backups remote access.
+
+_Note: All the SSH parameters are optional but if you pass `ssh-user` you will need to either pass `ssh-pass` or `ssh-private-key`. Setting SSH credentials is currently in beta._
 
 ### Provisioning a single plan for a given site
 


### PR DESCRIPTION
Documented the new SSH credential options when running the `partner-provision.sh` script.

Also, per @ebinnion's request, marked the feature as beta until the issue with Chronos is resolved (pa0RFL-k6-p2).