### PR TITLE
Removed beta notices from all SSH credentials related docs.

### DIFF
--- a/jetpack/plan-provisioning-direct-api.md
+++ b/jetpack/plan-provisioning-direct-api.md
@@ -113,7 +113,7 @@ Plans can be provisioned by making a request using your partner token from the s
 - __ssh_host__:        (optional) Set SSH host. Will be deduced from `siteurl` if missing.
 - __ssh_port__:        (optional) Set SSH port. Will default to 22 is missing.
 
-_Note: All the SSH parameters are optional but if you pass `ssh_user` you will need to either pass `ssh_pass` or `ssh_private_key`. Setting SSH credentials is currently in beta._
+_Note: All the SSH parameters are optional but if you pass `ssh_user` you will need to either pass `ssh_pass` or `ssh_private_key`._
 
 ### Response Parameters (/provision)
 

--- a/jetpack/plan-provisioning.md
+++ b/jetpack/plan-provisioning.md
@@ -37,7 +37,7 @@ Further in this document, you will find a few CLI commands with various argument
 - `ssh-private-key`       : The local path to the SSH private key file for Jetpack Backups remote access.
 - `ssh-port`              : The SSH port for Jetpack Backups remote access.
 
-_Note: All the SSH parameters are optional but if you pass `ssh-user` you will need to either pass `ssh-pass` or `ssh-private-key`. Setting SSH credentials is currently in beta._
+_Note: All the SSH parameters are optional but if you pass `ssh-user` you will need to either pass `ssh-pass` or `ssh-private-key`._
 
 ### Provisioning a single plan for a given site
 

--- a/jetpack/setting-backups-ssh-credentials.md
+++ b/jetpack/setting-backups-ssh-credentials.md
@@ -1,7 +1,5 @@
 # Setting Jetpack Backups SSH credentials
 
-_Setting SSH credentials is currently in beta._
-
 There are two ways to set Jetpack Backups SSH credentials. One way of doing this is during [plan provisioning](jetpack/plan-provisioning.md). The second one is by calling the `/jpphp/{blog_id}/ssh-credentials` endpoint directly. This document explains the latter.
 
 ## Getting an access token


### PR DESCRIPTION
Given that pa0RFL-k6-p2 is fully resolved both for Jetpack Backups as well as VaultPress, setting SSH credentials during provisioning will work properly no matter what backup system is used so the beta notices are no longer needed.