### PR TITLE
Add errors endpoint documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Monitor downtime notificatiosn webhook](jetpack/monitor-downtime-notifications-webhook.md)
   - [Magic mobile links](jetpack/mobile-magic-link.md)
   - [Setting Backups SSH credentials](jetpack/setting-backups-ssh-credentials.md)
+  - [Errors](jetpack/errors.md)
 - WooCommerce
   - [Overview](woocommerce/overview.md)
   - [Provison/Register plan](woocommerce/plan-register.md)

--- a/jetpack/errors.md
+++ b/jetpack/errors.md
@@ -2,10 +2,6 @@
 
 This endpoint returns the error codes than can be returned by the API. For each possible error, it contains a key and a description in English.
 
-## Getting an access token
-
-To query this endpoint, you'll first need to retrieve an access token. Information about that can be found on the [plan provisioning via API document]( plan-provisioning-direct-api.md#getting-a-jetpack-partner-access-token ).
-
 ## Endpoint Information
 
 - __Method__: GET
@@ -21,7 +17,6 @@ To query this endpoint, you'll first need to retrieve an access token. Informati
 curl --request GET \
   --url https://public-api.wordpress.com/rest/v1.3/jpphp/errors \
   --header 'Accept: */*' \
-  --header 'Authorization: Bearer $ACCESS_TOKEN' \
   --header 'Cache-Control: no-cache'
 ```
 

--- a/jetpack/errors.md
+++ b/jetpack/errors.md
@@ -1,6 +1,6 @@
 # Errors
 
-This endpoint returns the error codes than can be returned by the API. It contains an error key and a description in English.
+This endpoint returns the error codes than can be returned by the API. For each possible error, it contains a key and a description in English.
 
 ## Getting an access token
 

--- a/jetpack/errors.md
+++ b/jetpack/errors.md
@@ -1,0 +1,41 @@
+# Errors
+
+This endpoint returns the error codes than can be returned by the API. It contains an error key and a description in English.
+
+## Getting an access token
+
+To query this endpoint, you'll first need to retrieve an access token. Information about that can be found on the [plan provisioning via API document]( plan-provisioning-direct-api.md#getting-a-jetpack-partner-access-token ).
+
+## Endpoint Information
+
+- __Method__: GET
+- __URL__:    `https://public-api.wordpress.com/rest/v1.3/jpphp/errors`
+
+#### Successful response
+
+- __errors__:       (object) Errors list.
+
+### Example
+
+```shell
+curl --request GET \
+  --url https://public-api.wordpress.com/rest/v1.3/jpphp/errors \
+  --header 'Accept: */*' \
+  --header 'Authorization: Bearer $ACCESS_TOKEN' \
+  --header 'Cache-Control: no-cache'
+```
+
+### Example output
+
+Note: the output has been shortened to simplify the documentation. Please call the endpoint to get all the possible errors.
+
+```json
+{
+    "errors": {
+        "activation_limit_reached": "This key has reached its activation limit for product %s",
+        "could_not_load_product_class": "Could not load a product class",
+        "error_access_token": "Failed to create access token",
+        "failed_registration_unknown_blog": "Remote site returned an invalid site ID"
+    }
+}
+```


### PR DESCRIPTION
Added a new page to the docs for the `/errors` endpoint.

Note: **Do not merge** until D31939-code is deployed.