### PR TITLE
Update broken link on setting-backups-ssh-credentials.md

### DIFF
--- a/jetpack/jetpack-start-endpoints/setting-backups-ssh-credentials.md
+++ b/jetpack/jetpack-start-endpoints/setting-backups-ssh-credentials.md
@@ -1,6 +1,6 @@
 # Setting Jetpack Backups SSH credentials
 
-There are two ways to set Jetpack Backups SSH credentials. One way of doing this is during [plan provisioning](jetpack/plan-provisioning.md). The second one is by calling the `/jpphp/{blog_id}/ssh-credentials` endpoint directly. This document explains the latter.
+There are two ways to set Jetpack Backups SSH credentials. One way of doing this is during [plan provisioning](/jetpack/jetpack-start-endpoints/plan-provisioning.md). The second one is by calling the `/jpphp/{blog_id}/ssh-credentials` endpoint directly. This document explains the latter.
 
 ## Getting an access token
 


### PR DESCRIPTION
The link to plan provisioning was broken (pointed towards the old urls) and now it's fixed.