### PR TITLE
Add instructions on how to set FTP credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - [Monitor downtime notificatiosn webhook](jetpack/monitor-downtime-notifications-webhook.md)
   - [Magic mobile links](jetpack/jetpack-start-endpoints/mobile-magic-link.md)
   - [Setting Backups SSH credentials](jetpack/jetpack-start-endpoints/setting-backups-ssh-credentials.md)
+  - [Setting Backups FTP credentials](jetpack/jetpack-start-endpoints/setting-backups-ftp-credentials.md)
   - [Errors](jetpack/jetpack-start-endpoints/errors.md)
 - WooCommerce
   - [Overview](woocommerce/overview.md)

--- a/jetpack/jetpack-start-endpoints/determining-provisioning-status-v1.4.md
+++ b/jetpack/jetpack-start-endpoints/determining-provisioning-status-v1.4.md
@@ -38,7 +38,7 @@ To query this status endpoint, you'll first need to retrieve an access token. In
 
 - __blog__:                                (array) Blog specific information.
   - __is_connected__:                      (bool) Is the site connected to WordPress.com?
-  - __has_backups_credentials__:           (bool) Does the site have Jetpack Backup SSH credentials set?
+  - __has_backups_credentials__:           (bool) Does the site have Jetpack Backup SSH/FTP credentials set?
 - __products__:                            (array) A list with everything that was provisioned for this site.
   - __slug__:                              (string) The slug of the provisioned product.
   - __is_provisioned_by_partner__:         (bool) Was this product provisioned by a partner?

--- a/jetpack/jetpack-start-endpoints/determining-provisioning-status.md
+++ b/jetpack/jetpack-start-endpoints/determining-provisioning-status.md
@@ -41,7 +41,7 @@ To query this status endpoint, you'll first need to retrieve an access token. In
 - __is_provisioned_by_calling_partner__: (bool) Does the site have a plan that was provisioned by the partner making this status request?
 - __is_connected__:                      (bool) Is the site connected to WordPress.com?
 - __has_pending_plan__:                  (bool) Does the site have a pending plan that requires connection authorization?
-- __has_backups_credentials__:           (bool) Does the site have Jetpack Backup SSH credentials set?
+- __has_backups_credentials__:           (bool) Does the site have Jetpack Backup SSH/FTP credentials set?
 - __products__:                          (array) Additional product items provisioned for the site including Jetpack backups products and other items.
   - __product__:                         (string) The slug of the provisioned product.
   - __is_partner_product__:              (bool) Was this product provisioned by a partner?

--- a/jetpack/jetpack-start-endpoints/plan-provisioning.md
+++ b/jetpack/jetpack-start-endpoints/plan-provisioning.md
@@ -27,6 +27,10 @@ Plans can be provisioned by making a request using your partner token from the s
 - __ssh_private_key__: (optional) Set SSH private key.
 - __ssh_host__:        (optional) Set SSH host. Will be deduced from `siteurl` if missing.
 - __ssh_port__:        (optional) Set SSH port. Will default to 22 is missing.
+- __ftp_user__:        (optional) Set FTP user.
+- __ftp_pass__:        (optional) Set FTP password.
+- __ftp_host__:        (optional) Set FTP host. Will be deduced from `siteurl` if missing.
+- __ftp_port__:        (optional) Set FTP port. Will default to 21 is missing.
 
 _Note: All the SSH parameters are optional but if you pass `ssh_user` you will need to either pass `ssh_pass` or `ssh_private_key`._
 

--- a/jetpack/jetpack-start-endpoints/setting-backups-ftp-credentials.md
+++ b/jetpack/jetpack-start-endpoints/setting-backups-ftp-credentials.md
@@ -14,10 +14,10 @@ To query this endpoint, you'll first need to retrieve an access token. Informati
 
 ### Request Parameters
 
-- __ssh_user__:                    Set FTP user.
-- __ssh_pass__:        (optional*) Set FTP password.
-- __ssh_host__:                    Set FTP host.
-- __ssh_port__:        (optional)  Set FTP port. Will default to 21 is missing.
+- __ftp_user__:                    Set FTP user.
+- __ftp_pass__:        (optional)  Set FTP password.
+- __ftp_host__:                    Set FTP host.
+- __ftp_port__:        (optional)  Set FTP port. Will default to 21 is missing.
 
 #### Successful response
 

--- a/jetpack/jetpack-start-endpoints/setting-backups-ftp-credentials.md
+++ b/jetpack/jetpack-start-endpoints/setting-backups-ftp-credentials.md
@@ -1,0 +1,43 @@
+# Setting Jetpack Backups FTP credentials
+
+There are two ways to set Jetpack Backups FTP credentials. One way of doing this is during [plan provisioning](jetpack/plan-provisioning.md). The second one is by calling the `/jpphp/{blog_id}/ftp-credentials` endpoint directly. This document explains the latter.
+
+## Getting an access token
+
+To query this endpoint, you'll first need to retrieve an access token. Information about that can be found on the [Authentication API document]( jetpack/../authentication.md#getting-a-jetpack-partner-access-token ).
+
+## Endpoint Information
+- __Method__: POST
+- __URL__:    `https://public-api.wordpress.com/rest/v1.3/jpphp/{$blog_id}/ftp-credentials`
+
+`$blog_id` is the is the WordPress.com blog id.
+
+### Request Parameters
+
+- __ssh_user__:                    Set FTP user.
+- __ssh_pass__:        (optional*) Set FTP password.
+- __ssh_host__:                    Set FTP host.
+- __ssh_port__:        (optional)  Set FTP port. Will default to 21 is missing.
+
+#### Successful response
+
+- __success__:       (bool) Was the operation successful?
+
+#### Errored response
+
+- __error_code__:    (string) Error code, if any.
+- __error_message__: (string) Error message, if any.
+
+### Example
+
+```shell
+curl --request POST \
+  --url https://public-api.wordpress.com/rest/v1.3/jpphp/$BLOG_ID/ftp-credentials \
+  --header 'Accept: */*' \
+  --header 'Authorization: Bearer $ACCESS_TOKEN' \
+  --header 'Cache-Control: no-cache' \
+  --header 'Host: public-api.wordpress.com' \
+  --form ftp_host=$FTP_HOST \
+  --form ftp_user=$FTP_USER \
+  --form ftp_pass=$FTP_PASS
+```


### PR DESCRIPTION
- Added new page for the new FTP credentials endpoint.
- Updated status endpoints to say SSH/FTP instead of just SSH.
- Updated parameters on provisioning endpoint to feature the new FTP params.