### PR TITLE
Deprecate Jetpack Start shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you have any technical questions or concerns, don’t hesitate to get in touc
   - Jetpack Start API:
       - [Authentication](jetpack/jetpack-start-endpoints/authentication.md)
       - Plan provisioning
-        - [Via CLI](jetpack/plan-provisioning.md)
+        - ~~[Via CLI](jetpack/plan-provisioning.md)~~ (deprecated)
         - [Via direct API call](jetpack/jetpack-start-endpoints/plan-provisioning.md)
       - Checking status
         - [Connection status](jetpack/determining-connection-status.md)

--- a/jetpack/jetpack-start-endpoints/plan-provisioning.md
+++ b/jetpack/jetpack-start-endpoints/plan-provisioning.md
@@ -1,12 +1,12 @@
-# Provisioning Jetpack Plans
-
-In [another document](../../jetpack/plan-provisioning.md), we discussed how to provision and cancel plans by using the shell script that ships with Jetpack. But, for partners where running shell commands won't work, it is possible to communicate directly to the API on WordPress.com.
-
 If you have any questions or issues, our contact information can be found on the [README.md document](../../README.md).
+
+## What is Jetpack Start?
+
+Jetpack Start is a collection of endpoints that you can call in order to provision and cancel Jetpack plans for your customers. These endpoints also take care of activating any plan-specific features or activating additional plugin dependencies such as Akismet.
 
 ## Provisioning a plan
 
-Plans can be provisioned by making a request using your partner token from the step above along with local_user, siteurl, and plan parameters.
+Plans can be provisioned by making a request using your partner token along with local_user, siteurl, and plan parameters.
 
 ### Pending Activation
 

--- a/jetpack/plan-provisioning.md
+++ b/jetpack/plan-provisioning.md
@@ -1,3 +1,5 @@
+# DEPRECATED: Please see docs on how to use the API directly.
+
 # Provisioning and Cancelling Jetpack Plans
 
 In this document, we’ll briefly go over how to provision and cancel Jetpack plans via the shell scripts that ship with Jetpack. If you have any questions or issues, our contact information can be found on the [README.md document](../README.md).


### PR DESCRIPTION
The shell scripts to provision/cancel plans are no longer on the Jetpack plugin since 2021. This PR adds deprecation notices and changes the wording slightly to avoid confusion.

Context: p1701873194228469-slack-C053ZV01C3V